### PR TITLE
Enable WAL encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ The `create_cluster.sh` script will output a token which can be used to connect 
 To create an initial backup run:
 
     incus exec pgbackrest -- sudo -u postgres pgbackrest --stanza=tde --type=full backup
+
+To test a restore then run for example:
+
+    incus exec db-restore -- sudo -u postgres pgbackrest --target-action --stanza=tde restore
+    incus exec db-restore -- sudo -u postgres /lib/postgresql/17/bin/pg_ctl -D /var/lib/postgresql/patroni-17 start
+    incus exec db-restore -- sudo -u postgres touch /var/lib/postgresql/patroni-17/recovery.signal

--- a/cluster.yml
+++ b/cluster.yml
@@ -8,7 +8,7 @@
   tasks:
     - name: Install dependencies
       ansible.builtin.apt:
-        pkg:
+        name:
           - jq
           - opensc
           - softhsm
@@ -86,7 +86,7 @@
 
     - name: Install dependencies
       ansible.builtin.apt:
-        pkg:
+        name:
           - openssh-server
           - percona-patroni
           - percona-pgbackrest
@@ -164,7 +164,7 @@
   tasks:
     - name: Install etcd
       ansible.builtin.apt:
-        pkg: etcd-server
+        name: etcd-server
 
     - name: Add etcd config
       ansible.builtin.template:
@@ -190,7 +190,7 @@
 
     - name: Install PgBackRest
       ansible.builtin.apt:
-        pkg:
+        name:
           - openssh-server
           - percona-pgbackrest
         cache_valid_time: 1

--- a/cluster.yml
+++ b/cluster.yml
@@ -99,8 +99,36 @@
           - openssh-server
           - patroni
           - percona-pgbackrest
-          - percona-postgresql-17
         cache_valid_time: 1
+
+    - name: Install build dependencies
+      ansible.builtin.apt:
+        name: percona-postgresql-17
+        state: build-dep
+        cache_valid_time: 1
+
+    - name: Install git and other dependencies
+      ansible.builtin.apt:
+        name:
+          - git
+          - libcurl4-openssl-dev
+        cache_valid_time: 1
+
+    - name: Chekcout percona/postgres
+      ansible.builtin.git:
+        repo: https://github.com/percona/postgres.git
+        dest: /srv/postgres
+        version: TDE_REL_17_STABLE
+        depth: 1
+        force: true
+
+    - name: Configure PostgreSQL
+      ansible.builtin.command: ./configure --prefix=/lib/postgresql/17
+      args:
+        chdir: /srv/postgres
+
+    - name: Build and install PostgreSQL
+      ansible.builtin.command: make -j4 -s -C /srv/postgres install-world
 
     - name: Disable PgBackRest server
       ansible.builtin.service:

--- a/cluster.yml
+++ b/cluster.yml
@@ -62,7 +62,9 @@
       openbao_architecture_map:
         x86_64: amd64
 
-- hosts: db
+- hosts:
+    - db
+    - db-restore
   tasks:
     - name: Add Percona repo
       ansible.builtin.apt:
@@ -157,6 +159,20 @@
         dest: /etc/pgbackrest.conf
         src: pgbackrest-pg.conf
 
+    - name: Add OpenBao root token
+      ansible.builtin.copy:
+        dest: /var/lib/postgresql/vault-token
+        src: fetch/keyring/root/.vault-token
+        owner: postgres
+        mode: "600"
+
+- hosts: db
+  tasks:
+    - name: Install Patroni
+      ansible.builtin.apt:
+        name: patroni
+        cache_valid_time: 1
+
     - name: Add Patroni config
       ansible.builtin.template:
         dest: /etc/patroni/config.yml
@@ -165,13 +181,6 @@
         owner: postgres
       vars:
         secret: hunter2
-
-    - name: Add OpenBao root token
-      ansible.builtin.copy:
-        dest: /var/lib/postgresql/vault-token
-        src: fetch/keyring/root/.vault-token
-        owner: postgres
-        mode: '0600'
 
     - name: Add cluster setup script
       ansible.builtin.copy:
@@ -260,6 +269,7 @@
       with_items:
         - db1
         - db2
+        - db-restore
 
     - name: Add PgBackRest config
       ansible.builtin.copy:

--- a/cluster.yml
+++ b/cluster.yml
@@ -73,6 +73,15 @@
       args:
         creates: /etc/apt/sources.list.d/percona-ppg-17-release.list
 
+    - name: Add PGDG repo
+      ansible.builtin.deb822_repository:
+        name: pgdg
+        types: deb
+        uris: https://apt.postgresql.org/pub/repos/apt
+        suites: bookworm-pgdg
+        components: main
+        signed_by: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+
     - name: Create createcluster config dir
       ansible.builtin.file:
         path: /etc/postgresql-common/createcluster.d
@@ -88,7 +97,7 @@
       ansible.builtin.apt:
         name:
           - openssh-server
-          - percona-patroni
+          - patroni
           - percona-pgbackrest
           - percona-postgresql-17
         cache_valid_time: 1
@@ -122,7 +131,7 @@
 
     - name: Add Patroni config
       ansible.builtin.template:
-        dest: /etc/patroni/patroni.yml
+        dest: /etc/patroni/config.yml
         src: patroni.yml.j2
         mode: "600"
         owner: postgres
@@ -154,10 +163,9 @@
         src: patronictl.yaml
         mode: "600"
 
-    - name: Enable Patroni
+    - name: Start Patroni
       ansible.builtin.service:
         name: patroni
-        enabled: true
         state: started
 
 - hosts: etcd

--- a/create_cluster.sh
+++ b/create_cluster.sh
@@ -4,7 +4,7 @@ set -e
 
 SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-for instance in db1 db2 pgbackrest keyring etcd1 etcd2 etcd3; do
+for instance in db1 db2 db-restore pgbackrest keyring etcd1 etcd2 etcd3; do
     incus launch images:debian/12 "$instance"
 done
 

--- a/delete_cluster.sh
+++ b/delete_cluster.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-incus delete -f db1 db2 pgbackrest keyring etcd1 etcd2 etcd3
+incus delete -f db1 db2 db-restore pgbackrest keyring etcd1 etcd2 etcd3

--- a/files/pgbackrest-pg.conf
+++ b/files/pgbackrest-pg.conf
@@ -4,3 +4,4 @@ repo1-host-user=postgres
 
 [tde]
 pg1-path=/var/lib/postgresql/patroni-17
+pg1-socket-path=/tmp

--- a/files/pgbackrest-pg.conf
+++ b/files/pgbackrest-pg.conf
@@ -1,6 +1,7 @@
 [global]
 repo1-host=pgbackrest
 repo1-host-user=postgres
+recovery-option=restore_command=/lib/postgresql/17/bin/pg_tde_restore_encrypt %f %p pgbackrest --stanza=tde archive-get %f "%p"
 
 [tde]
 pg1-path=/var/lib/postgresql/patroni-17

--- a/files/pgbackrest-repo.conf
+++ b/files/pgbackrest-repo.conf
@@ -7,5 +7,7 @@ repo1-retention-full=7
 [tde]
 pg1-host=db1
 pg1-path=/var/lib/postgresql/patroni-17
+pg1-socket-path=/tmp
 pg2-host=db2
 pg2-path=/var/lib/postgresql/patroni-17
+pg2-socket-path=/tmp

--- a/files/setup_cluster.sh
+++ b/files/setup_cluster.sh
@@ -4,4 +4,13 @@ set -e
 
 psql -v ON_ERROR_STOP=on "$1" <<SQL
 CREATE EXTENSION pg_tde;
+
+SELECT pg_tde_add_global_key_provider_vault_v2('global', 'http://keyring:8200', 'kv', '/var/lib/postgresql/vault-token', NULL);
+
+SELECT pg_tde_create_key_using_global_key_provider('server-key', 'global');
+SELECT pg_tde_set_server_key_using_global_key_provider('server-key', 'global');
+
+ALTER SYSTEM SET pg_tde.wal_encrypt = on;
 SQL
+
+/lib/postgresql/17/bin/pg_ctl restart -D /var/lib/postgresql/patroni-17

--- a/hosts
+++ b/hosts
@@ -1,5 +1,6 @@
-pgbackrest
+db-restore
 keyring
+pgbackrest
 
 [db]
 db1

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -46,7 +46,7 @@ postgresql:
       username: postgres
       password: {{secret}}
   parameters:
-    unix_socket_directories: /var/run/postgresql
+    unix_socket_directories: /tmp
 watchdog:
   mode: off
 tags:

--- a/templates/patroni.yml.j2
+++ b/templates/patroni.yml.j2
@@ -15,9 +15,9 @@ bootstrap:
     postgresql:
       use_pg_rewind: true
       parameters:
-        archive_command: "pgbackrest --stanza=tde archive-push %p"
+        archive_command: "/lib/postgresql/17/bin/pg_tde_archive_decrypt %p pgbackrest --stanza=tde archive-push %p"
         archive_mode: "on"
-        restore_command: "pgbackrest --stanza=tde archive-get %f \"%p\""
+        restore_command: "/lib/postgresql/17/bin/pg_tde_restore_encrypt %f %p pgbackrest --stanza=tde archive-get %f \"%p\""
       pg_hba:
         - local all all peer
         - host all all 0.0.0.0/0 scram-sha-256


### PR DESCRIPTION
This enables WAL encryption support for the cluster which requires use to build PostgreSQL from the git repo to get all nice features. In the future we might make building from package vs git an argument to the playbook but for now let's just support building from git. We also had to use Patroni from PGDG to avoid a dependency issue when building from source.

Additionally we add a new Incus server, `db-restore`, which simplifies testing restore from PgBackRest.