### PR TITLE
Disable checksumming when doing backups

### DIFF
--- a/files/pgbackrest-pg.conf
+++ b/files/pgbackrest-pg.conf
@@ -1,8 +1,8 @@
 [global]
 repo1-host=pgbackrest
 repo1-host-user=postgres
-recovery-option=restore_command=/lib/postgresql/17/bin/pg_tde_restore_encrypt %f %p "pgbackrest --stanza=tde archive-get %%f \"%%p\""
 
 [tde]
 pg1-path=/var/lib/postgresql/patroni-17
 pg1-socket-path=/tmp
+recovery-option=restore_command=/lib/postgresql/17/bin/pg_tde_restore_encrypt %f %p "pgbackrest --stanza=tde archive-get %%f \"%%p\""

--- a/files/pgbackrest-repo.conf
+++ b/files/pgbackrest-repo.conf
@@ -11,3 +11,4 @@ pg1-socket-path=/tmp
 pg2-host=db2
 pg2-path=/var/lib/postgresql/patroni-17
 pg2-socket-path=/tmp
+checksum-page=n


### PR DESCRIPTION
Since checksums are encrypted when using pg_tde we need to disable checksumming to avoid getting spammed with warnings.

Also move a config option to the correct section.