### PR TITLE
Fix timeoute issue when starting Patroni

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -62,6 +62,23 @@
       openbao_architecture_map:
         x86_64: amd64
 
+- hosts: etcd
+  tasks:
+    - name: Install etcd
+      ansible.builtin.apt:
+        name: etcd-server
+
+    - name: Add etcd config
+      ansible.builtin.template:
+        dest: /etc/default/etcd
+        src: etcd.j2
+      notify: Restart etcd
+  handlers:
+    - name: Restart etcd
+      service:
+        name: etcd
+        state: restarted
+
 - hosts:
     - db
     - db-restore
@@ -204,23 +221,6 @@
       ansible.builtin.service:
         name: patroni
         state: started
-
-- hosts: etcd
-  tasks:
-    - name: Install etcd
-      ansible.builtin.apt:
-        name: etcd-server
-
-    - name: Add etcd config
-      ansible.builtin.template:
-        dest: /etc/default/etcd
-        src: etcd.j2
-      notify: Restart etcd
-  handlers:
-    - name: Restart etcd
-      service:
-        name: etcd
-        state: restarted
 
 - hosts: pgbackrest
   tasks:

--- a/cluster.yml
+++ b/cluster.yml
@@ -218,9 +218,10 @@
         mode: "600"
 
     - name: Start Patroni
-      ansible.builtin.service:
+      ansible.builtin.systemd_service:
         name: patroni
         state: started
+        no_block: true
 
 - hosts: pgbackrest
   tasks:


### PR DESCRIPTION
Patroni has for some reason now started to timeout `systemctl start percona-patroni` so we do two changes.

1. Start etcd earlier
2. Do not wait for Patroni to start and just let it start in the backgroun